### PR TITLE
feat(skills-manager): add antigravity-skills-manager skill, pure stdlib CLI engine, and plugin manifest

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -15,7 +15,11 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - run: npm ci
       - run: npm test
+      - run: npm run test:python
       - run: STRICT=1 npm run validate:skills
       - run: npm run check:catalog

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+__pycache__/
 .DS_Store
 *.log
 .agent/

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,8 +1,8 @@
 # Skill Catalog
 
-Generated at: 2026-06-14T17:50:31.666Z
+Generated at: 2026-08-02T00:22:52.027Z
 
-Total skills: 306
+Total skills: 307
 
 ## architecture (30)
 
@@ -152,13 +152,14 @@ Total skills: 306
 | `typescript-pro` | Master TypeScript with advanced types, generics, and strict type safety. Handles complex type systems, decorators, and enterprise-grade patterns. Use PROACTI... | typescript | typescript, pro, types, generics, strict, type, safety, complex, decorators, enterprise, grade, proactively |
 | `uv-package-manager` | Master the uv package manager for fast Python dependency management, virtual environments, and modern Python project workflows. Use when setting up Python pr... | uv, package, manager | uv, package, manager, fast, python, dependency, virtual, environments, setting, up, managing, dependencies |
 
-## general (37)
+## general (38)
 
 | Skill | Description | Tags | Triggers |
 | --- | --- | --- | --- |
 | `accessibility-compliance-accessibility-audit` | You are an accessibility expert specializing in WCAG compliance, inclusive design, and assistive technology compatibility. Conduct audits, identify barriers,... | accessibility, compliance, audit | accessibility, compliance, audit, specializing, wcag, inclusive, assistive, technology, compatibility, conduct, audits, identify |
 | `angular-migration` | Migrate from AngularJS to Angular using hybrid mode, incremental component rewriting, and dependency injection updates. Use when upgrading AngularJS applicat... | angular, migration | angular, migration, migrate, angularjs, hybrid, mode, incremental, component, rewriting, dependency, injection, updates |
 | `anti-reversing-techniques` | Understand anti-reversing, obfuscation, and protection techniques encountered during software analysis. Use when analyzing protected binaries, bypassing anti... | anti, reversing, techniques | anti, reversing, techniques, understand, obfuscation, protection, encountered, during, software, analysis, analyzing, protected |
+| `antigravity-skills-manager` | Global skills manager for Google Antigravity. Explore, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog using pur... | antigravity, skills, manager | antigravity, skills, manager, global, google, explore, search, install, 300, agent, rmyndharis, catalog |
 | `arm-cortex-expert` | Senior embedded software engineer specializing in firmware and driver development for ARM Cortex-M microcontrollers (Teensy, STM32, nRF52, SAMD). Decades of ... | arm, cortex | arm, cortex, senior, embedded, software, engineer, specializing, firmware, driver, development, microcontrollers, teensy |
 | `article-illustrations` | Generate hand-drawn 16:9 article illustrations featuring the Grav character IP. Turns article concepts into memorable whiteboard-sketch explanations with a r... | article, illustrations | article, illustrations, generate, hand, drawn, 16, featuring, grav, character, ip, turns, concepts |
 | `backtesting-frameworks` | Build robust backtesting systems for trading strategies with proper handling of look-ahead bias, survivorship bias, and transaction costs. Use when developin... | backtesting, frameworks | backtesting, frameworks, robust, trading, proper, handling, look, ahead, bias, survivorship, transaction, costs |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ You can install skills in **two scopes**:
 -   **Workspace scope** (project-specific): `<workspace-root>/.agent/skills/`
 -   **Global scope** (available in all projects): `~/.gemini/antigravity/skills/`
 
-### Using `agy plugin install` (Native AGY CLI)
+### Using `agy plugin install` (Native AGY CLI) — experimental
+
+> **Experimental.** The plugin manifest below has not yet been verified end-to-end against a
+> released `agy` CLI. If `agy plugin install` does not pick it up, use the `npx` or manual
+> instructions below, which are the supported paths. Reports are welcome in the issue tracker.
 
 You can install this repository directly as a native Antigravity plugin:
 
@@ -109,7 +113,7 @@ This registers the `antigravity-skills-manager` plugin and enables `/skills-mana
   # Example:
   /skills-manager search flutter
   ```
-- **Install a skill to `~/.gemini/config/skills/`:**
+- **Install a skill to `~/.gemini/antigravity/skills/`:**
   ```bash
   /skills-manager install <skill_id>
   # Example:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ You can install skills in **two scopes**:
 -   **Workspace scope** (project-specific): `<workspace-root>/.agent/skills/`
 -   **Global scope** (available in all projects): `~/.gemini/antigravity/skills/`
 
+### Using `agy plugin install` (Native AGY CLI)
+
+You can install this repository directly as a native Antigravity plugin:
+
+```bash
+agy plugin install https://github.com/rmyndharis/antigravity-skills
+```
+
+This registers the `antigravity-skills-manager` plugin and enables `/skills-manager` (or `/skills`) slash commands inside Antigravity:
+
+- **List available catalog skills:**
+  ```bash
+  /skills-manager list
+  ```
+- **Search skills by keyword:**
+  ```bash
+  /skills-manager search <term>
+  # Example:
+  /skills-manager search flutter
+  ```
+- **Install a skill to `~/.gemini/config/skills/`:**
+  ```bash
+  /skills-manager install <skill_id>
+  # Example:
+  /skills-manager install flutter-expert
+  ```
+- **List locally installed skills:**
+  ```bash
+  /skills-manager installed
+  ```
+
+*(Note: `/skills` is also available as a short command alias.)*
+
 ### Using `npx` (Recommended)
 
 You can easily install skills directly from the repository without cloning it manually.

--- a/aliases.json
+++ b/aliases.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T17:50:31.666Z",
+  "generatedAt": "2026-08-02T00:22:52.027Z",
   "aliases": {
     "accessibility-compliance-audit": "accessibility-compliance-accessibility-audit",
     "agent-orchestration-improve": "agent-orchestration-improve-agent",

--- a/bundles.json
+++ b/bundles.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T17:50:31.666Z",
+  "generatedAt": "2026-08-02T00:22:52.027Z",
   "bundles": {
     "core-dev": {
       "description": "Core development skills across languages, frameworks, and backend/frontend fundamentals.",

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-14T17:50:31.666Z",
-  "total": 306,
+  "generatedAt": "2026-08-02T00:22:52.027Z",
+  "total": 307,
   "skills": [
     {
       "id": "accessibility-compliance-accessibility-audit",
@@ -178,6 +178,32 @@
         "protected"
       ],
       "path": "skills/anti-reversing-techniques/SKILL.md"
+    },
+    {
+      "id": "antigravity-skills-manager",
+      "name": "antigravity-skills-manager",
+      "description": "Global skills manager for Google Antigravity. Explore, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog using pure stdlib CLI tools.",
+      "category": "general",
+      "tags": [
+        "antigravity",
+        "skills",
+        "manager"
+      ],
+      "triggers": [
+        "antigravity",
+        "skills",
+        "manager",
+        "global",
+        "google",
+        "explore",
+        "search",
+        "install",
+        "300",
+        "agent",
+        "rmyndharis",
+        "catalog"
+      ],
+      "path": "skills/antigravity-skills-manager/SKILL.md"
     },
     {
       "id": "api-design-principles",

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/yudhi/Codes/antigravity-skills/node_modules

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "validation-baseline.json",
     "bundles.json",
     "aliases.json",
+    "plugin.json",
+    "skills_cli.py",
     "SECURITY.md",
     "LICENSE",
     "README.md"
@@ -23,7 +25,8 @@
     "build:catalog": "node scripts/build-catalog.js",
     "validate:skills": "node scripts/validate-skills.js",
     "check:catalog": "node scripts/check-catalog-drift.js",
-    "test": "node --test"
+    "test": "node --test",
+    "test:python": "python3 -m unittest discover -s tests -p \"test_*.py\""
   },
   "repository": {
     "type": "git",

--- a/plugin.json
+++ b/plugin.json
@@ -1,16 +1,41 @@
 {
-  "name": "antigravity-skills",
+  "name": "antigravity-skills-manager",
   "version": "1.2.0",
   "description": "Antigravity Skill Manager - Global agy plugin to browse, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog.",
   "author": "tonicofonico",
-  "repository": "https://github.com/tonicofonico/antigravity-skills",
-  "homepage": "https://github.com/tonicofonico/antigravity-skills#readme",
+  "repository": "https://github.com/rmyndharis/antigravity-skills",
+  "homepage": "https://github.com/rmyndharis/antigravity-skills#readme",
   "license": "MIT",
   "entry": "skills_cli.py",
   "skills": [
     "skills/antigravity-skills-manager/SKILL.md"
   ],
   "commands": [
+    {
+      "name": "skills-manager",
+      "description": "Browse, search, install, and manage Antigravity agent skills",
+      "entry": "skills_cli.py",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all available skills in the catalog"
+        },
+        {
+          "name": "search",
+          "description": "Search skills by keyword in name, category, or tags",
+          "args": "<term>"
+        },
+        {
+          "name": "install",
+          "description": "Install a skill to ~/.gemini/config/skills/<skill_id>/",
+          "args": "<skill_id>"
+        },
+        {
+          "name": "installed",
+          "description": "List all locally installed skills"
+        }
+      ]
+    },
     {
       "name": "skills",
       "description": "Browse, search, install, and manage Antigravity agent skills",
@@ -38,3 +63,4 @@
     }
   ]
 }
+

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "antigravity-skills",
+  "version": "1.2.0",
+  "description": "Antigravity Skill Manager - Global agy plugin to browse, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog.",
+  "author": "tonicofonico",
+  "repository": "https://github.com/tonicofonico/antigravity-skills",
+  "homepage": "https://github.com/tonicofonico/antigravity-skills#readme",
+  "license": "MIT",
+  "entry": "skills_cli.py",
+  "skills": [
+    "skills/antigravity-skills-manager/SKILL.md"
+  ],
+  "commands": [
+    {
+      "name": "skills",
+      "description": "Browse, search, install, and manage Antigravity agent skills",
+      "entry": "skills_cli.py",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all available skills in the catalog"
+        },
+        {
+          "name": "search",
+          "description": "Search skills by keyword in name, category, or tags",
+          "args": "<term>"
+        },
+        {
+          "name": "install",
+          "description": "Install a skill to ~/.gemini/config/skills/<skill_id>/",
+          "args": "<skill_id>"
+        },
+        {
+          "name": "installed",
+          "description": "List all locally installed skills"
+        }
+      ]
+    }
+  ]
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "antigravity-skills-manager",
   "version": "1.2.0",
-  "description": "Antigravity Skill Manager - Global agy plugin to browse, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog.",
-  "author": "tonicofonico",
+  "description": "Antigravity Skill Manager - Global agy plugin to browse, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog. Experimental: not yet verified end-to-end against a released agy CLI.",
+  "author": "rmyndharis",
   "repository": "https://github.com/rmyndharis/antigravity-skills",
   "homepage": "https://github.com/rmyndharis/antigravity-skills#readme",
   "license": "MIT",
@@ -27,7 +27,7 @@
         },
         {
           "name": "install",
-          "description": "Install a skill to ~/.gemini/config/skills/<skill_id>/",
+          "description": "Install a skill to ~/.gemini/antigravity/skills/<skill_id>/",
           "args": "<skill_id>"
         },
         {
@@ -52,7 +52,7 @@
         },
         {
           "name": "install",
-          "description": "Install a skill to ~/.gemini/config/skills/<skill_id>/",
+          "description": "Install a skill to ~/.gemini/antigravity/skills/<skill_id>/",
           "args": "<skill_id>"
         },
         {

--- a/scripts/build-catalog.js
+++ b/scripts/build-catalog.js
@@ -313,7 +313,7 @@ function computeArtifacts() {
       category,
       tags,
       triggers,
-      path: path.relative(ROOT, skill.path),
+      path: path.relative(ROOT, skill.path).replace(/\\/g, '/'),
     });
   }
 

--- a/scripts/check-catalog-drift.js
+++ b/scripts/check-catalog-drift.js
@@ -28,7 +28,7 @@ function stripGeneratedAt(obj) {
 }
 
 function stripMarkdownTimestamp(md) {
-  return md.replace(/^Generated at: .*$/m, 'Generated at: <timestamp>');
+  return md.replace(/\r\n/g, '\n').replace(/^Generated at: .*$/m, 'Generated at: <timestamp>');
 }
 
 // Pure comparison: returns the list of artifact names that differ between the

--- a/skills/antigravity-skills-manager/SKILL.md
+++ b/skills/antigravity-skills-manager/SKILL.md
@@ -14,7 +14,7 @@ The `antigravity-skills-manager` skill empowers Google Antigravity agents and us
 ## Use this skill when
 
 - Searching or exploring available agent skills in the `antigravity-skills` catalog.
-- Installing a new skill into the global Antigravity configuration directory (`~/.gemini/config/skills/<skill_id>/`).
+- Installing a new skill into the global Antigravity configuration directory (`~/.gemini/antigravity/skills/<skill_id>/`).
 - Listing locally installed skills to check system capabilities.
 - Managing skill updates or auditing active agent tools.
 
@@ -28,8 +28,17 @@ The `antigravity-skills-manager` skill empowers Google Antigravity agents and us
 ## Instructions
 
 - Execute commands via `skills_cli.py` or through `/skills-manager` (or `/skills`) slash commands in the CLI chat interface.
-- Ensure skill installations save to `~/.gemini/config/skills/<skill_id>/SKILL.md`.
+- Ensure skill installations save to `~/.gemini/antigravity/skills/<skill_id>/SKILL.md`.
 - All underlying commands must use standard Python library features (`urllib.request`, `json`, `os`, `sys`) without third-party dependencies.
+
+---
+
+## Safety
+
+- `install` writes instructions that every future Antigravity session loads automatically. Confirm the skill id with the user before installing, and show them what `search` returned rather than picking on their behalf.
+- `install` replaces an existing installation of the same skill id, discarding local edits under that directory. Say so before overwriting.
+- Never install a skill id the user did not ask for, and never install one that is absent from the catalog.
+- `install` writes only under the global skills directory; report the exact path back to the user.
 
 ---
 
@@ -42,14 +51,14 @@ Provide a unified, lightweight, pure standard-library interface for managing Goo
 ## Available Commands & Usage
 
 ### 1. List Catalog Skills
-Lists all 300+ available skills with their categories and descriptions:
+Lists catalog skills with their categories and descriptions. An unfiltered listing is capped at the first 40 entries with a count of the remainder; add a filter to see a complete result set:
 ```bash
 python skills_cli.py list
 ```
 *Slash command equivalent*: `/skills-manager list` (or `/skills list`)
 
 ### 2. Search Catalog Skills
-Filters skills by matching keywords in skill name, description, category, or tags:
+Filters skills by matching keywords in skill id, name, description, category, tags, or triggers. Multi-word queries match skills containing every term, in any order, and results are never truncated:
 ```bash
 python skills_cli.py search <term>
 ```
@@ -60,7 +69,7 @@ python skills_cli.py search flutter
 *Slash command equivalent*: `/skills-manager search flutter` (or `/skills search flutter`)
 
 ### 3. Install Skill
-Downloads target skill folder and `SKILL.md` directly into local configuration path (`~/.gemini/config/skills/<skill_id>/`):
+Installs the whole skill folder into the global skills directory (`~/.gemini/antigravity/skills/<skill_id>/`), copying from the catalog shipped beside the script when present and downloading from GitHub otherwise. Any existing installation of the same id is replaced. Exits non-zero if some files could not be retrieved:
 ```bash
 python skills_cli.py install <skill_id>
 ```
@@ -71,7 +80,7 @@ python skills_cli.py install flutter-expert
 *Slash command equivalent*: `/skills-manager install flutter-expert` (or `/skills install flutter-expert`)
 
 ### 4. List Installed Skills
-Inspects local `~/.gemini/config/skills/` directory and lists installed skills:
+Inspects local `~/.gemini/antigravity/skills/` directory and lists installed skills:
 ```bash
 python skills_cli.py installed
 ```
@@ -82,8 +91,8 @@ python skills_cli.py installed
 ## Local Installation Storage Path
 
 Skill files installed via this skill are placed in:
-`~/.gemini/config/skills/<skill_id>/SKILL.md`
+`~/.gemini/antigravity/skills/<skill_id>/SKILL.md`
 
-On Windows: `C:\Users\<user>\.gemini\config\skills\<skill_id>\SKILL.md`
+On Windows: `C:\Users\<user>\.gemini\antigravity\skills\<skill_id>\SKILL.md`
 
 Newly installed skills are automatically discovered by Google Antigravity upon session initialization or refresh.

--- a/skills/antigravity-skills-manager/SKILL.md
+++ b/skills/antigravity-skills-manager/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: antigravity-skills-manager
+description: Global skills manager for Google Antigravity. Explore, search, install, and manage 300+ agent skills from the rmyndharis/antigravity-skills catalog using pure stdlib CLI tools.
+metadata:
+  model: inherit
+---
+
+# 📦 Antigravity Skills Manager (`rmyndharis/antigravity-skills`)
+
+The `antigravity-skills-manager` skill empowers Google Antigravity agents and users to discover, search, install, and manage over **300+ agent skills** from the open-source repository [`rmyndharis/antigravity-skills`](https://github.com/rmyndharis/antigravity-skills).
+
+---
+
+## Use this skill when
+
+- Searching or exploring available agent skills in the `antigravity-skills` catalog.
+- Installing a new skill into the global Antigravity configuration directory (`~/.gemini/config/skills/<skill_id>/`).
+- Listing locally installed skills to check system capabilities.
+- Managing skill updates or auditing active agent tools.
+
+## Do not use this skill when
+
+- Performing general domain coding tasks that do not involve discovering or managing skills.
+- Working on tasks outside the scope of Antigravity skill management.
+
+---
+
+## Instructions
+
+- Execute commands via `skills_cli.py` or through `/skills` slash commands in the CLI chat interface.
+- Ensure skill installations save to `~/.gemini/config/skills/<skill_id>/SKILL.md`.
+- All underlying commands must use standard Python library features (`urllib.request`, `json`, `os`, `sys`) without third-party dependencies.
+
+---
+
+## Purpose
+
+Provide a unified, lightweight, pure standard-library interface for managing Google Antigravity agent skills across platforms (Windows, macOS, Linux).
+
+---
+
+## Available Commands & Usage
+
+### 1. List Catalog Skills
+Lists all 300+ available skills with their categories and descriptions:
+```bash
+python skills_cli.py list
+```
+*Slash command equivalent*: `/skills list`
+
+### 2. Search Catalog Skills
+Filters skills by matching keywords in skill name, description, category, or tags:
+```bash
+python skills_cli.py search <term>
+```
+*Example*:
+```bash
+python skills_cli.py search flutter
+```
+*Slash command equivalent*: `/skills search flutter`
+
+### 3. Install Skill
+Downloads target skill folder and `SKILL.md` directly into local configuration path (`~/.gemini/config/skills/<skill_id>/`):
+```bash
+python skills_cli.py install <skill_id>
+```
+*Example*:
+```bash
+python skills_cli.py install flutter-expert
+```
+*Slash command equivalent*: `/skills install flutter-expert`
+
+### 4. List Installed Skills
+Inspects local `~/.gemini/config/skills/` directory and lists installed skills:
+```bash
+python skills_cli.py installed
+```
+*Slash command equivalent*: `/skills installed`
+
+---
+
+## Local Installation Storage Path
+
+Skill files installed via this skill are placed in:
+`~/.gemini/config/skills/<skill_id>/SKILL.md`
+
+On Windows: `C:\Users\<user>\.gemini\config\skills\<skill_id>\SKILL.md`
+
+Newly installed skills are automatically discovered by Google Antigravity upon session initialization or refresh.

--- a/skills/antigravity-skills-manager/SKILL.md
+++ b/skills/antigravity-skills-manager/SKILL.md
@@ -27,7 +27,7 @@ The `antigravity-skills-manager` skill empowers Google Antigravity agents and us
 
 ## Instructions
 
-- Execute commands via `skills_cli.py` or through `/skills` slash commands in the CLI chat interface.
+- Execute commands via `skills_cli.py` or through `/skills-manager` (or `/skills`) slash commands in the CLI chat interface.
 - Ensure skill installations save to `~/.gemini/config/skills/<skill_id>/SKILL.md`.
 - All underlying commands must use standard Python library features (`urllib.request`, `json`, `os`, `sys`) without third-party dependencies.
 
@@ -46,7 +46,7 @@ Lists all 300+ available skills with their categories and descriptions:
 ```bash
 python skills_cli.py list
 ```
-*Slash command equivalent*: `/skills list`
+*Slash command equivalent*: `/skills-manager list` (or `/skills list`)
 
 ### 2. Search Catalog Skills
 Filters skills by matching keywords in skill name, description, category, or tags:
@@ -57,7 +57,7 @@ python skills_cli.py search <term>
 ```bash
 python skills_cli.py search flutter
 ```
-*Slash command equivalent*: `/skills search flutter`
+*Slash command equivalent*: `/skills-manager search flutter` (or `/skills search flutter`)
 
 ### 3. Install Skill
 Downloads target skill folder and `SKILL.md` directly into local configuration path (`~/.gemini/config/skills/<skill_id>/`):
@@ -68,14 +68,14 @@ python skills_cli.py install <skill_id>
 ```bash
 python skills_cli.py install flutter-expert
 ```
-*Slash command equivalent*: `/skills install flutter-expert`
+*Slash command equivalent*: `/skills-manager install flutter-expert` (or `/skills install flutter-expert`)
 
 ### 4. List Installed Skills
 Inspects local `~/.gemini/config/skills/` directory and lists installed skills:
 ```bash
 python skills_cli.py installed
 ```
-*Slash command equivalent*: `/skills installed`
+*Slash command equivalent*: `/skills-manager installed` (or `/skills installed`)
 
 ---
 

--- a/skills_cli.py
+++ b/skills_cli.py
@@ -1,24 +1,44 @@
 import sys
 import os
 import json
+import shutil
 import urllib.request
 import urllib.error
 
-# ponytail: reconfigure sys.stdout/stderr to UTF-8 for Windows terminal compatibility
+# Reconfigure sys.stdout/stderr to UTF-8 for Windows terminal compatibility.
 if hasattr(sys.stdout, 'reconfigure'):
     sys.stdout.reconfigure(encoding='utf-8')
     sys.stderr.reconfigure(encoding='utf-8')
 
 CATALOG_URL = "https://raw.githubusercontent.com/rmyndharis/antigravity-skills/main/catalog.json"
-BUNDLES_URL = "https://raw.githubusercontent.com/rmyndharis/antigravity-skills/main/bundles.json"
 RAW_BASE_URL = "https://raw.githubusercontent.com/rmyndharis/antigravity-skills/main/"
 API_BASE_URL = "https://api.github.com/repos/rmyndharis/antigravity-skills/contents/"
 
-# ponytail: environment variable override allows isolated testing without polluting ~/.gemini/config/skills
-def get_skills_dir():
-    return os.environ.get("GEMINI_SKILLS_DIR") or os.path.abspath(os.path.join(os.path.expanduser("~"), ".gemini", "config", "skills"))
+GLOBAL_SKILLS_DIR = os.path.join(os.path.expanduser("~"), ".gemini", "antigravity", "skills")
 
-# ponytail: stdlib urllib fetcher with user-agent and timeout handling
+
+# Mirrors resolveTargetDir() in bin/cli.js: AG_SKILLS_DIR overrides the destination and a
+# leading ~ is expanded, so this CLI and ag-skills always agree on where skills live.
+def get_skills_dir():
+    override = os.environ.get("AG_SKILLS_DIR")
+    if override:
+        if override == "~" or override.startswith(("~/", "~\\")):
+            override = os.path.expanduser("~") + override[1:]
+        return os.path.abspath(override)
+    return os.path.abspath(GLOBAL_SKILLS_DIR)
+
+
+# Keep every write under the install root, so a catalog entry can never place files
+# elsewhere on disk via .. or an absolute path. Mirrors the guard in bin/cli.js.
+def contained_join(base, *parts):
+    base_abs = os.path.abspath(base)
+    target = os.path.abspath(os.path.join(base_abs, *parts))
+    if target != base_abs and not target.startswith(base_abs + os.sep):
+        raise ValueError(f"refusing to write outside {base_abs}: {target}")
+    return target
+
+
+# Stdlib urllib fetcher with user-agent and timeout handling.
 def fetch_json(url):
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "AntigravitySkillsInstaller/1.0"})
@@ -28,7 +48,7 @@ def fetch_json(url):
         print(f"Error fetching {url}: {e}", file=sys.stderr)
         return None
 
-# ponytail: stdlib binary fetcher for raw files
+# Stdlib binary fetcher for raw files.
 def fetch_bytes(url):
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "AntigravitySkillsInstaller/1.0"})
@@ -38,7 +58,7 @@ def fetch_bytes(url):
         print(f"Error downloading {url}: {e}", file=sys.stderr)
         return None
 
-# ponytail: prefer local catalog.json if available in script directory, fallback to raw github
+# Prefer the catalog.json shipped next to this script; fall back to raw GitHub.
 def load_catalog():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     local_catalog = os.path.join(script_dir, "catalog.json")
@@ -53,20 +73,18 @@ def load_catalog():
 def skill_matches(s, query):
     if not query:
         return True
-    q = query.lower()
-    if q in s.get('id', '').lower():
-        return True
-    if q in s.get('name', '').lower():
-        return True
-    if q in s.get('description', '').lower():
-        return True
-    if q in s.get('category', '').lower():
-        return True
-    if any(q in t.lower() for t in s.get('tags', [])):
-        return True
-    if any(q in tr.lower() for tr in s.get('triggers', [])):
-        return True
-    return False
+    haystack = " ".join([
+        s.get('id', ''),
+        s.get('name', ''),
+        s.get('description', ''),
+        s.get('category', ''),
+        " ".join(s.get('tags', [])),
+        " ".join(s.get('triggers', [])),
+    ]).lower()
+    # Match on every whitespace-separated token rather than the whole string, so
+    # "kubernetes helm" finds skills mentioning both instead of requiring that
+    # exact adjacent phrase (which no catalog entry contains).
+    return all(token in haystack for token in query.lower().split())
 
 def cmd_list(category=None, query=None):
     catalog = load_catalog()
@@ -90,14 +108,17 @@ def cmd_list(category=None, query=None):
         print("No skills found matching filter.")
         return
 
-    for s in skills[:40]:  # Limit display to 40 items
+    # Cap only the unfiltered listing; a filtered result set is small enough to show
+    # in full, and truncating it would let a caller conclude a skill does not exist.
+    limit = None if (category or query) else 40
+    for s in (skills if limit is None else skills[:limit]):
         cat = f"[{s.get('category', 'general')}]"
         print(f"* {s.get('id', ''):<50} {cat:<12}")
         if s.get('description'):
             desc = s['description'][:80] + "..." if len(s['description']) > 80 else s['description']
             print(f"  └─ {desc}")
-    if len(skills) > 40:
-        print(f"\n... and {len(skills) - 40} more. Use --query <term> or search <term> to filter.")
+    if limit is not None and len(skills) > limit:
+        print(f"\n... and {len(skills) - limit} more. Use --query <term> or search <term> to filter.")
 
 def cmd_search(query):
     if not query or not query.strip():
@@ -105,37 +126,38 @@ def cmd_search(query):
         sys.exit(1)
     cmd_list(query=query.strip())
 
-# ponytail: local repo fallback for offline/test reliability
+# Local source copy, used whenever the repo's skills/ tree sits beside this script.
 def copy_folder_local(local_src, local_dst):
     os.makedirs(local_dst, exist_ok=True)
-    for root, dirs, files in os.walk(local_src):
+    for root, _dirs, files in os.walk(local_src):
         rel_path = os.path.relpath(root, local_src)
-        target_dir = os.path.join(local_dst, rel_path) if rel_path != "." else local_dst
+        target_dir = local_dst if rel_path == "." else contained_join(local_dst, rel_path)
         os.makedirs(target_dir, exist_ok=True)
         for f in files:
             src_file = os.path.join(root, f)
-            dst_file = os.path.join(target_dir, f)
+            dst_file = contained_join(target_dir, f)
             with open(src_file, "rb") as rf:
                 content = rf.read()
             with open(dst_file, "wb") as wf:
                 wf.write(content)
-            print(f"  └─ Downloaded: {f}")
+            print(f"  └─ Copied: {f}")
     return True
 
-# ponytail: recursive directory fetcher using github api with raw fallback
+# Recursive directory fetcher using the GitHub contents API, with a raw fallback.
 def download_folder_recursive(remote_path, local_target_dir):
     os.makedirs(local_target_dir, exist_ok=True)
     api_url = API_BASE_URL + remote_path
     items = fetch_json(api_url)
     if not items or not isinstance(items, list):
-        # ponytail: fallback to direct SKILL.md download if GitHub API fails or rate limited
+        # The contents API is unavailable (commonly an unauthenticated rate limit), so the
+        # folder cannot be enumerated. Fetch SKILL.md alone and report the install as
+        # incomplete rather than claiming success for files that were never listed.
         raw_url = RAW_BASE_URL + remote_path + "/SKILL.md"
         content = fetch_bytes(raw_url)
         if content:
-            with open(os.path.join(local_target_dir, "SKILL.md"), "wb") as f:
+            with open(contained_join(local_target_dir, "SKILL.md"), "wb") as f:
                 f.write(content)
-            print("  └─ Downloaded: SKILL.md (fallback)")
-            return True
+            print("  └─ Downloaded: SKILL.md (folder listing unavailable, other files skipped)")
         return False
 
     success = True
@@ -143,7 +165,7 @@ def download_folder_recursive(remote_path, local_target_dir):
         item_name = item.get('name', '')
         item_path = item.get('path', '')
         item_type = item.get('type', '')
-        target_item_path = os.path.join(local_target_dir, item_name)
+        target_item_path = contained_join(local_target_dir, item_name)
 
         if item_type == 'file':
             download_url = item.get('download_url') or (RAW_BASE_URL + item_path)
@@ -183,8 +205,17 @@ def cmd_install(skill_id):
         sys.exit(1)
 
     skills_dir = get_skills_dir()
-    target_skill_dir = os.path.join(skills_dir, found['id'])
+    try:
+        target_skill_dir = contained_join(skills_dir, found['id'])
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     print(f"[*] Installing skill '{found['id']}' into: {target_skill_dir}")
+
+    # Replace rather than merge, so files removed upstream do not survive a reinstall.
+    if os.path.isdir(target_skill_dir):
+        print("  └─ Replacing existing installation")
+        shutil.rmtree(target_skill_dir)
 
     cat_path = found.get('path', '')
     if cat_path and cat_path.endswith('/SKILL.md'):
@@ -197,15 +228,22 @@ def cmd_install(skill_id):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     local_skill_src = os.path.join(script_dir, remote_skill_path)
 
-    if os.path.exists(local_skill_src) and os.path.isdir(local_skill_src):
-        ok = copy_folder_local(local_skill_src, target_skill_dir)
-    else:
-        ok = download_folder_recursive(remote_skill_path, target_skill_dir)
+    try:
+        if os.path.exists(local_skill_src) and os.path.isdir(local_skill_src):
+            ok = copy_folder_local(local_skill_src, target_skill_dir)
+        else:
+            ok = download_folder_recursive(remote_skill_path, target_skill_dir)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if ok and os.path.exists(os.path.join(target_skill_dir, "SKILL.md")):
         print(f"[OK] Successfully installed '{found['id']}'!")
     else:
-        print(f"[!] Installation completed with potential missing files for '{found['id']}'.")
+        # Exit non-zero so callers and wrappers can tell a partial install from a clean one,
+        # matching how bin/cli.js sets process.exitCode on a failed install.
+        print(f"[!] Installation incomplete for '{found['id']}' - some files could not be retrieved.", file=sys.stderr)
+        sys.exit(1)
 
 def cmd_installed():
     skills_dir = get_skills_dir()

--- a/skills_cli.py
+++ b/skills_cli.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 import json
 import shutil
 import urllib.request
@@ -26,6 +27,24 @@ def get_skills_dir():
             override = os.path.expanduser("~") + override[1:]
         return os.path.abspath(override)
     return os.path.abspath(GLOBAL_SKILLS_DIR)
+
+
+# A catalog entry's path is used three ways: as a local directory to read from, as a
+# suffix on the pinned GitHub API and raw URLs, and as a destination folder name. A
+# ".." segment therefore escapes far more than the filesystem — in a URL it walks off
+# the pinned repo prefix entirely, so
+#   API_BASE_URL + "../../../../other-org/other-repo/contents/x"
+# resolves to a repository we do not control. Match the exact shape build-catalog.js
+# emits instead of scrubbing, and reject everything else.
+SKILL_PATH_RE = re.compile(r'^skills/([A-Za-z0-9._-]+)/SKILL\.md$')
+
+
+def skill_folder_from_catalog(cat_path, skill_id):
+    candidate = cat_path or f"skills/{skill_id}/SKILL.md"
+    match = SKILL_PATH_RE.match(candidate)
+    if not match or match.group(1) in ('.', '..'):
+        raise ValueError(f"unsafe skill path in catalog entry: {candidate!r}")
+    return candidate[:-len('/SKILL.md')]
 
 
 # Keep every write under the install root, so a catalog entry can never place files
@@ -167,8 +186,19 @@ def download_folder_recursive(remote_path, local_target_dir):
         item_type = item.get('type', '')
         target_item_path = contained_join(local_target_dir, item_name)
 
+        # The API response also feeds URLs and recursion, so hold it to the same rule as
+        # the catalog: everything must stay under the folder we asked for, on our host.
+        if not item_path.startswith(remote_path + "/"):
+            print(f"  └─ Skipped (outside {remote_path}): {item_path}", file=sys.stderr)
+            success = False
+            continue
+
         if item_type == 'file':
             download_url = item.get('download_url') or (RAW_BASE_URL + item_path)
+            if not download_url.startswith(RAW_BASE_URL):
+                print(f"  └─ Skipped (unexpected download host): {download_url}", file=sys.stderr)
+                success = False
+                continue
             data = fetch_bytes(download_url)
             if data is not None:
                 with open(target_item_path, "wb") as f:
@@ -206,6 +236,7 @@ def cmd_install(skill_id):
 
     skills_dir = get_skills_dir()
     try:
+        remote_skill_path = skill_folder_from_catalog(found.get('path', ''), found['id'])
         target_skill_dir = contained_join(skills_dir, found['id'])
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -217,16 +248,8 @@ def cmd_install(skill_id):
         print("  └─ Replacing existing installation")
         shutil.rmtree(target_skill_dir)
 
-    cat_path = found.get('path', '')
-    if cat_path and cat_path.endswith('/SKILL.md'):
-        remote_skill_path = cat_path[:-len('/SKILL.md')]
-    elif cat_path:
-        remote_skill_path = os.path.dirname(cat_path)
-    else:
-        remote_skill_path = f"skills/{found['id']}"
-
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    local_skill_src = os.path.join(script_dir, remote_skill_path)
+    local_skill_src = contained_join(script_dir, remote_skill_path)
 
     try:
         if os.path.exists(local_skill_src) and os.path.isdir(local_skill_src):

--- a/skills_cli.py
+++ b/skills_cli.py
@@ -1,0 +1,259 @@
+import sys
+import os
+import json
+import urllib.request
+import urllib.error
+
+# ponytail: reconfigure sys.stdout/stderr to UTF-8 for Windows terminal compatibility
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stderr.reconfigure(encoding='utf-8')
+
+CATALOG_URL = "https://raw.githubusercontent.com/rmyndharis/antigravity-skills/main/catalog.json"
+BUNDLES_URL = "https://raw.githubusercontent.com/rmyndharis/antigravity-skills/main/bundles.json"
+RAW_BASE_URL = "https://raw.githubusercontent.com/rmyndharis/antigravity-skills/main/"
+API_BASE_URL = "https://api.github.com/repos/rmyndharis/antigravity-skills/contents/"
+
+# ponytail: environment variable override allows isolated testing without polluting ~/.gemini/config/skills
+def get_skills_dir():
+    return os.environ.get("GEMINI_SKILLS_DIR") or os.path.abspath(os.path.join(os.path.expanduser("~"), ".gemini", "config", "skills"))
+
+# ponytail: stdlib urllib fetcher with user-agent and timeout handling
+def fetch_json(url):
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "AntigravitySkillsInstaller/1.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+    except Exception as e:
+        print(f"Error fetching {url}: {e}", file=sys.stderr)
+        return None
+
+# ponytail: stdlib binary fetcher for raw files
+def fetch_bytes(url):
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "AntigravitySkillsInstaller/1.0"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.read()
+    except Exception as e:
+        print(f"Error downloading {url}: {e}", file=sys.stderr)
+        return None
+
+# ponytail: prefer local catalog.json if available in script directory, fallback to raw github
+def load_catalog():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    local_catalog = os.path.join(script_dir, "catalog.json")
+    if os.path.exists(local_catalog):
+        try:
+            with open(local_catalog, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return fetch_json(CATALOG_URL)
+
+def skill_matches(s, query):
+    if not query:
+        return True
+    q = query.lower()
+    if q in s.get('id', '').lower():
+        return True
+    if q in s.get('name', '').lower():
+        return True
+    if q in s.get('description', '').lower():
+        return True
+    if q in s.get('category', '').lower():
+        return True
+    if any(q in t.lower() for t in s.get('tags', [])):
+        return True
+    if any(q in tr.lower() for tr in s.get('triggers', [])):
+        return True
+    return False
+
+def cmd_list(category=None, query=None):
+    catalog = load_catalog()
+    if catalog is None or 'skills' not in catalog:
+        print("Failed to load catalog.", file=sys.stderr)
+        sys.exit(1)
+
+    skills = catalog['skills']
+    if not skills:
+        print("\n[+] Found 0 skill(s) in catalog:\n" + "-"*60)
+        print("No skills available in catalog.")
+        return
+
+    if category:
+        skills = [s for s in skills if s.get('category', '').lower() == category.lower()]
+    if query:
+        skills = [s for s in skills if skill_matches(s, query)]
+
+    print(f"\n[+] Found {len(skills)} skill(s) in catalog:\n" + "-"*60)
+    if not skills:
+        print("No skills found matching filter.")
+        return
+
+    for s in skills[:40]:  # Limit display to 40 items
+        cat = f"[{s.get('category', 'general')}]"
+        print(f"* {s.get('id', ''):<50} {cat:<12}")
+        if s.get('description'):
+            desc = s['description'][:80] + "..." if len(s['description']) > 80 else s['description']
+            print(f"  └─ {desc}")
+    if len(skills) > 40:
+        print(f"\n... and {len(skills) - 40} more. Use --query <term> or search <term> to filter.")
+
+def cmd_search(query):
+    if not query or not query.strip():
+        print("Usage: python skills_cli.py search <term>", file=sys.stderr)
+        sys.exit(1)
+    cmd_list(query=query.strip())
+
+# ponytail: local repo fallback for offline/test reliability
+def copy_folder_local(local_src, local_dst):
+    os.makedirs(local_dst, exist_ok=True)
+    for root, dirs, files in os.walk(local_src):
+        rel_path = os.path.relpath(root, local_src)
+        target_dir = os.path.join(local_dst, rel_path) if rel_path != "." else local_dst
+        os.makedirs(target_dir, exist_ok=True)
+        for f in files:
+            src_file = os.path.join(root, f)
+            dst_file = os.path.join(target_dir, f)
+            with open(src_file, "rb") as rf:
+                content = rf.read()
+            with open(dst_file, "wb") as wf:
+                wf.write(content)
+            print(f"  └─ Downloaded: {f}")
+    return True
+
+# ponytail: recursive directory fetcher using github api with raw fallback
+def download_folder_recursive(remote_path, local_target_dir):
+    os.makedirs(local_target_dir, exist_ok=True)
+    api_url = API_BASE_URL + remote_path
+    items = fetch_json(api_url)
+    if not items or not isinstance(items, list):
+        # ponytail: fallback to direct SKILL.md download if GitHub API fails or rate limited
+        raw_url = RAW_BASE_URL + remote_path + "/SKILL.md"
+        content = fetch_bytes(raw_url)
+        if content:
+            with open(os.path.join(local_target_dir, "SKILL.md"), "wb") as f:
+                f.write(content)
+            print("  └─ Downloaded: SKILL.md (fallback)")
+            return True
+        return False
+
+    success = True
+    for item in items:
+        item_name = item.get('name', '')
+        item_path = item.get('path', '')
+        item_type = item.get('type', '')
+        target_item_path = os.path.join(local_target_dir, item_name)
+
+        if item_type == 'file':
+            download_url = item.get('download_url') or (RAW_BASE_URL + item_path)
+            data = fetch_bytes(download_url)
+            if data is not None:
+                with open(target_item_path, "wb") as f:
+                    f.write(data)
+                print(f"  └─ Downloaded: {item_name}")
+            else:
+                success = False
+        elif item_type == 'dir':
+            dir_ok = download_folder_recursive(item_path, target_item_path)
+            if not dir_ok:
+                success = False
+
+    return success
+
+def cmd_install(skill_id):
+    if not skill_id or not skill_id.strip():
+        print("Please specify skill name/id to install.", file=sys.stderr)
+        sys.exit(1)
+
+    skill_id_clean = skill_id.strip()
+    catalog = load_catalog()
+    if catalog is None or 'skills' not in catalog:
+        print("Failed to load catalog.", file=sys.stderr)
+        sys.exit(1)
+
+    found = None
+    for s in catalog['skills']:
+        if s.get('id', '').lower() == skill_id_clean.lower() or s.get('name', '').lower() == skill_id_clean.lower():
+            found = s
+            break
+
+    if not found:
+        print(f"Error: Skill '{skill_id_clean}' not found in catalog.", file=sys.stderr)
+        sys.exit(1)
+
+    skills_dir = get_skills_dir()
+    target_skill_dir = os.path.join(skills_dir, found['id'])
+    print(f"[*] Installing skill '{found['id']}' into: {target_skill_dir}")
+
+    cat_path = found.get('path', '')
+    if cat_path and cat_path.endswith('/SKILL.md'):
+        remote_skill_path = cat_path[:-len('/SKILL.md')]
+    elif cat_path:
+        remote_skill_path = os.path.dirname(cat_path)
+    else:
+        remote_skill_path = f"skills/{found['id']}"
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    local_skill_src = os.path.join(script_dir, remote_skill_path)
+
+    if os.path.exists(local_skill_src) and os.path.isdir(local_skill_src):
+        ok = copy_folder_local(local_skill_src, target_skill_dir)
+    else:
+        ok = download_folder_recursive(remote_skill_path, target_skill_dir)
+
+    if ok and os.path.exists(os.path.join(target_skill_dir, "SKILL.md")):
+        print(f"[OK] Successfully installed '{found['id']}'!")
+    else:
+        print(f"[!] Installation completed with potential missing files for '{found['id']}'.")
+
+def cmd_installed():
+    skills_dir = get_skills_dir()
+    if not os.path.exists(skills_dir):
+        print("No skills currently installed.")
+        return
+
+    dirs = [d for d in os.listdir(skills_dir) if os.path.isdir(os.path.join(skills_dir, d))]
+    if not dirs:
+        print("No skills currently installed.")
+        return
+
+    print(f"\n[*] Installed Skills in {skills_dir} ({len(dirs)} total):\n" + "-"*60)
+    for d in sorted(dirs):
+        skill_md = os.path.join(skills_dir, d, "SKILL.md")
+        has_md = "[OK] SKILL.md" if os.path.exists(skill_md) else "[X] No SKILL.md"
+        print(f"* {d:<50} {has_md}")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python skills_cli.py [list|search|install|installed] [args]")
+        sys.exit(1)
+
+    cmd = sys.argv[1].lower()
+    if cmd == "list":
+        cat = None
+        q = None
+        if len(sys.argv) > 2:
+            if sys.argv[2] == "--category" and len(sys.argv) > 3:
+                cat = sys.argv[3]
+            elif sys.argv[2] == "--query" and len(sys.argv) > 3:
+                q = sys.argv[3]
+            else:
+                q = sys.argv[2]
+        cmd_list(category=cat, query=q)
+    elif cmd == "search":
+        q = " ".join(sys.argv[2:]) if len(sys.argv) > 2 else ""
+        cmd_search(q)
+    elif cmd == "install":
+        if len(sys.argv) < 3:
+            print("Please specify skill name/id to install.", file=sys.stderr)
+            sys.exit(1)
+        cmd_install(sys.argv[2])
+    elif cmd == "installed":
+        cmd_installed()
+    else:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_schema_valid.py
+++ b/tests/test_schema_valid.py
@@ -1,0 +1,98 @@
+import unittest
+import os
+import json
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+class TestSchemaValid(unittest.TestCase):
+    def test_plugin_json_schema(self):
+        plugin_path = os.path.join(REPO_ROOT, "plugin.json")
+        self.assertTrue(os.path.exists(plugin_path), "plugin.json does not exist at repo root")
+        
+        with open(plugin_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        data = json.loads(content)
+        self.assertIsInstance(data, dict, "plugin.json must contain a JSON object")
+
+        # Validate name
+        self.assertIn("name", data, "plugin.json missing 'name'")
+        self.assertIsInstance(data["name"], str)
+        self.assertTrue(re.match(r"^[a-z0-9]+(?:-[a-z0-9]+)*$", data["name"]), f"Invalid plugin name format: {data['name']}")
+
+        # Validate version
+        self.assertIn("version", data, "plugin.json missing 'version'")
+        self.assertIsInstance(data["version"], str)
+        self.assertTrue(re.match(r"^\d+\.\d+\.\d+$", data["version"]), f"Invalid semantic version: {data['version']}")
+
+        # Validate description
+        self.assertIn("description", data, "plugin.json missing 'description'")
+        self.assertIsInstance(data["description"], str)
+        self.assertTrue(len(data["description"].strip()) > 0, "description cannot be empty")
+        self.assertLessEqual(len(data["description"]), 256, "description exceeds 256 chars")
+
+        # Validate entry
+        self.assertIn("entry", data, "plugin.json missing 'entry'")
+        self.assertEqual(data["entry"], "skills_cli.py")
+
+        # Validate skills list
+        self.assertIn("skills", data)
+        self.assertIsInstance(data["skills"], list)
+        self.assertIn("skills/antigravity-skills-manager/SKILL.md", data["skills"])
+
+        # Validate commands
+        self.assertIn("commands", data)
+        self.assertIsInstance(data["commands"], list)
+        self.assertTrue(len(data["commands"]) > 0)
+        skills_cmd = data["commands"][0]
+        self.assertEqual(skills_cmd.get("name"), "skills")
+        self.assertIn("subcommands", skills_cmd)
+        sub_names = [sc["name"] for sc in skills_cmd["subcommands"]]
+        self.assertIn("list", sub_names)
+        self.assertIn("search", sub_names)
+        self.assertIn("install", sub_names)
+        self.assertIn("installed", sub_names)
+
+    def test_skill_md_schema(self):
+        skill_md_path = os.path.join(REPO_ROOT, "skills", "antigravity-skills-manager", "SKILL.md")
+        self.assertTrue(os.path.exists(skill_md_path), f"SKILL.md missing at {skill_md_path}")
+
+        with open(skill_md_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        self.assertLessEqual(len(lines), 500, "SKILL.md exceeds 500 lines limit")
+
+        content = "".join(lines)
+        self.assertTrue(content.startswith("---"), "SKILL.md must start with YAML frontmatter delimiter '---'")
+
+        # Extract frontmatter
+        parts = content.split("---", 2)
+        self.assertGreaterEqual(len(parts), 3, "SKILL.md must have valid closing YAML frontmatter delimiter '---'")
+        frontmatter_raw = parts[1]
+
+        # Parse key-values from frontmatter
+        allowed_fields = {"name", "description", "license", "compatibility", "allowed-tools", "metadata"}
+        fm_keys = set()
+        for raw_line in frontmatter_raw.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" in line:
+                key = line.split(":", 1)[0].strip()
+                if not raw_line.startswith(" ") and not raw_line.startswith("\t"):
+                    fm_keys.add(key)
+
+        for k in fm_keys:
+            self.assertIn(k, allowed_fields, f"Disallowed key '{k}' found in SKILL.md frontmatter")
+
+        self.assertIn("name", fm_keys, "Frontmatter missing 'name'")
+        self.assertIn("description", fm_keys, "Frontmatter missing 'description'")
+
+        # Section headers check
+        self.assertIn("## Use this skill when", content)
+        self.assertTrue("## Do not use" in content or "## Do not use this skill when" in content)
+        self.assertIn("## Instructions", content)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_schema_valid.py
+++ b/tests/test_schema_valid.py
@@ -45,14 +45,16 @@ class TestSchemaValid(unittest.TestCase):
         self.assertIn("commands", data)
         self.assertIsInstance(data["commands"], list)
         self.assertTrue(len(data["commands"]) > 0)
-        skills_cmd = data["commands"][0]
-        self.assertEqual(skills_cmd.get("name"), "skills")
-        self.assertIn("subcommands", skills_cmd)
-        sub_names = [sc["name"] for sc in skills_cmd["subcommands"]]
-        self.assertIn("list", sub_names)
-        self.assertIn("search", sub_names)
-        self.assertIn("install", sub_names)
-        self.assertIn("installed", sub_names)
+        cmds_by_name = {c["name"]: c for c in data["commands"] if isinstance(c, dict) and "name" in c}
+        for cmd_name in ["skills-manager", "skills"]:
+            self.assertIn(cmd_name, cmds_by_name, f"Command '{cmd_name}' missing from commands in plugin.json")
+            cmd = cmds_by_name[cmd_name]
+            self.assertIn("subcommands", cmd)
+            sub_names = [sc["name"] for sc in cmd["subcommands"] if isinstance(sc, dict) and "name" in sc]
+            self.assertIn("list", sub_names)
+            self.assertIn("search", sub_names)
+            self.assertIn("install", sub_names)
+            self.assertIn("installed", sub_names)
 
     def test_skill_md_schema(self):
         skill_md_path = os.path.join(REPO_ROOT, "skills", "antigravity-skills-manager", "SKILL.md")

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -221,6 +221,48 @@ class TestSkillsCLI(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertFalse(os.path.exists(stale))
 
+    # TC-CLI-INST-08: A catalog path must not read from outside the package
+    @patch('skills_cli.load_catalog')
+    def test_install_refuses_catalog_path_traversal(self, mock_catalog):
+        secrets = tempfile.mkdtemp()
+        with open(os.path.join(secrets, 'id_rsa'), 'w', encoding='utf-8') as f:
+            f.write('private key material')
+        with open(os.path.join(secrets, 'SKILL.md'), 'w', encoding='utf-8') as f:
+            f.write('decoy')
+        rel = os.path.relpath(secrets, REPO_ROOT).replace(os.sep, '/')
+        mock_catalog.return_value = {'skills': [
+            {'id': 'innocent', 'name': 'innocent', 'path': f'{rel}/SKILL.md'}
+        ]}
+        code, out, err = self.run_cli(['install', 'innocent'])
+        self.assertEqual(code, 1)
+        self.assertIn("unsafe skill path", err)
+        self.assertFalse(os.path.exists(os.path.join(self.temp_dir.name, 'innocent', 'id_rsa')))
+
+    # TC-CLI-INST-09: A catalog path must not walk the pinned repo prefix off the URL
+    @patch('skills_cli.fetch_json')
+    @patch('skills_cli.load_catalog')
+    def test_install_refuses_url_repo_substitution(self, mock_catalog, mock_fetch):
+        mock_catalog.return_value = {'skills': [{
+            'id': 'innocent',
+            'name': 'innocent',
+            'path': 'skills/../../../../attacker-org/malicious-repo/contents/x/SKILL.md',
+        }]}
+        code, out, err = self.run_cli(['install', 'innocent'])
+        self.assertEqual(code, 1)
+        self.assertIn("unsafe skill path", err)
+        mock_fetch.assert_not_called()
+
+    # TC-CLI-INST-10: API items pointing outside the requested folder are skipped
+    def test_download_skips_items_outside_requested_folder(self):
+        target = os.path.join(self.temp_dir.name, 'out')
+        items = [{'name': 'evil.md', 'path': 'skills/other-skill/evil.md', 'type': 'file'}]
+        with patch('skills_cli.fetch_json', return_value=items), \
+             patch('skills_cli.fetch_bytes', return_value=b'x') as mock_bytes:
+            ok = skills_cli.download_folder_recursive('skills/innocent', target)
+        self.assertFalse(ok)
+        mock_bytes.assert_not_called()
+        self.assertFalse(os.path.exists(os.path.join(target, 'evil.md')))
+
     # TC-CLI-SEARCH-06: Multi-word queries match on every term, not the exact phrase
     @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
     def test_search_multi_word(self, mock_catalog):

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -40,12 +40,12 @@ MOCK_CATALOG = {
 class TestSkillsCLI(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
-        os.environ["GEMINI_SKILLS_DIR"] = self.temp_dir.name
+        os.environ["AG_SKILLS_DIR"] = self.temp_dir.name
 
     def tearDown(self):
         self.temp_dir.cleanup()
-        if "GEMINI_SKILLS_DIR" in os.environ:
-            del os.environ["GEMINI_SKILLS_DIR"]
+        if "AG_SKILLS_DIR" in os.environ:
+            del os.environ["AG_SKILLS_DIR"]
 
     def run_cli(self, args):
         stdout_capture = io.StringIO()
@@ -174,6 +174,60 @@ class TestSkillsCLI(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("dummy-folder", out)
         self.assertIn("[X] No SKILL.md", out)
+
+    # TC-CLI-DIR-01: Default destination is the same global dir bin/cli.js uses
+    def test_default_skills_dir_matches_node_cli(self):
+        del os.environ["AG_SKILLS_DIR"]
+        expected = os.path.join(os.path.expanduser("~"), ".gemini", "antigravity", "skills")
+        self.assertEqual(skills_cli.get_skills_dir(), os.path.abspath(expected))
+
+    # TC-CLI-DIR-02: AG_SKILLS_DIR expands a leading ~, as bin/cli.js does
+    def test_ag_skills_dir_expands_tilde(self):
+        os.environ["AG_SKILLS_DIR"] = "~/some-skills-dir"
+        resolved = skills_cli.get_skills_dir()
+        self.assertEqual(resolved, os.path.join(os.path.expanduser("~"), "some-skills-dir"))
+        self.assertNotIn("~", resolved)
+
+    # TC-CLI-INST-05: A failed install must exit non-zero, not report soft success
+    @patch('skills_cli.fetch_bytes', return_value=None)
+    @patch('skills_cli.fetch_json', return_value=None)
+    @patch('skills_cli.load_catalog', return_value={'skills': [
+        {'id': 'ghost-skill', 'name': 'ghost-skill', 'path': 'skills/ghost-skill/SKILL.md'}
+    ]})
+    def test_install_failure_exits_nonzero(self, mock_catalog, mock_json, mock_bytes):
+        code, out, err = self.run_cli(['install', 'ghost-skill'])
+        self.assertEqual(code, 1)
+        self.assertIn("Installation incomplete", err)
+
+    # TC-CLI-INST-06: A catalog id must not be able to write outside the skills dir
+    @patch('skills_cli.load_catalog', return_value={'skills': [
+        {'id': '../escaped', 'name': '../escaped', 'path': 'skills/api-design-principles/SKILL.md'}
+    ]})
+    def test_install_refuses_path_escape(self, mock_catalog):
+        code, out, err = self.run_cli(['install', '../escaped'])
+        self.assertEqual(code, 1)
+        self.assertIn("refusing to write outside", err)
+        escaped = os.path.join(os.path.dirname(self.temp_dir.name), 'escaped')
+        self.assertFalse(os.path.exists(escaped))
+
+    # TC-CLI-INST-07: Reinstalling replaces the folder so upstream deletions do not survive
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_reinstall_removes_stale_files(self, mock_catalog):
+        self.run_cli(['install', 'antigravity-skills-manager'])
+        stale = os.path.join(self.temp_dir.name, 'antigravity-skills-manager', 'stale-upstream-file.md')
+        with open(stale, 'w', encoding='utf-8') as f:
+            f.write('removed upstream')
+        code, out, err = self.run_cli(['install', 'antigravity-skills-manager'])
+        self.assertEqual(code, 0)
+        self.assertFalse(os.path.exists(stale))
+
+    # TC-CLI-SEARCH-06: Multi-word queries match on every term, not the exact phrase
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_search_multi_word(self, mock_catalog):
+        code, out, err = self.run_cli(['search', 'improve agent'])
+        self.assertEqual(code, 0)
+        self.assertIn("agent-orchestration-improve-agent", out)
+        self.assertIn("Found 1 skill(s)", out)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -1,0 +1,179 @@
+import unittest
+from unittest.mock import patch
+import sys
+import os
+import io
+import tempfile
+
+# Ensure repository root is in sys.path
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+import skills_cli
+
+MOCK_CATALOG = {
+    "generatedAt": "2026-08-02T00:00:00.000Z",
+    "total": 2,
+    "skills": [
+        {
+            "id": "antigravity-skills-manager",
+            "name": "antigravity-skills-manager",
+            "description": "Global skills manager for Google Antigravity.",
+            "category": "workflow",
+            "tags": ["skills", "installer", "manager"],
+            "triggers": ["skills", "skill"],
+            "path": "skills/antigravity-skills-manager/SKILL.md"
+        },
+        {
+            "id": "agent-orchestration-improve-agent",
+            "name": "agent-orchestration-improve-agent",
+            "description": "Systematic improvement of existing agents.",
+            "category": "workflow",
+            "tags": ["agent", "improve"],
+            "triggers": ["agent", "improve"],
+            "path": "skills/agent-orchestration-improve-agent/SKILL.md"
+        }
+    ]
+}
+
+class TestSkillsCLI(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.environ["GEMINI_SKILLS_DIR"] = self.temp_dir.name
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+        if "GEMINI_SKILLS_DIR" in os.environ:
+            del os.environ["GEMINI_SKILLS_DIR"]
+
+    def run_cli(self, args):
+        stdout_capture = io.StringIO()
+        stderr_capture = io.StringIO()
+        with patch.object(sys, 'argv', ['skills_cli.py'] + args):
+            with patch('sys.stdout', stdout_capture), patch('sys.stderr', stderr_capture):
+                exit_code = 0
+                try:
+                    skills_cli.main()
+                except SystemExit as e:
+                    exit_code = e.code if isinstance(e.code, int) else 1
+        return exit_code, stdout_capture.getvalue(), stderr_capture.getvalue()
+
+    # TC-CLI-LIST-01: List catalog skills
+    def test_list_skills(self):
+        code, out, err = self.run_cli(['list'])
+        self.assertEqual(code, 0)
+        self.assertIn("Found", out)
+
+    # TC-CLI-LIST-02: Empty catalog handling
+    @patch('skills_cli.load_catalog', return_value={'skills': []})
+    def test_list_empty_catalog(self, mock_catalog):
+        code, out, err = self.run_cli(['list'])
+        self.assertEqual(code, 0)
+        self.assertIn("Found 0 skill(s)", out)
+        self.assertIn("No skills available in catalog", out)
+
+    # TC-CLI-LIST-03: Malformed catalog error
+    @patch('skills_cli.load_catalog', return_value=None)
+    def test_list_malformed_catalog(self, mock_catalog):
+        code, out, err = self.run_cli(['list'])
+        self.assertEqual(code, 1)
+        self.assertIn("Failed to load catalog", err)
+
+    # TC-CLI-SEARCH-01: Match by ID/Name
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_search_manager(self, mock_catalog):
+        code, out, err = self.run_cli(['search', 'manager'])
+        self.assertEqual(code, 0)
+        self.assertIn("antigravity-skills-manager", out)
+
+    # TC-CLI-SEARCH-02: Case-insensitive search
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_search_case_insensitive(self, mock_catalog):
+        code, out, err = self.run_cli(['search', 'MANAGER'])
+        self.assertEqual(code, 0)
+        self.assertIn("antigravity-skills-manager", out)
+
+    # TC-CLI-SEARCH-03: Tag/Category match
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_search_workflow(self, mock_catalog):
+        code, out, err = self.run_cli(['search', 'workflow'])
+        self.assertEqual(code, 0)
+        self.assertIn("Found 2 skill(s)", out)
+
+    # TC-CLI-SEARCH-04: No matching results
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_search_no_match(self, mock_catalog):
+        code, out, err = self.run_cli(['search', 'nonexistent_xyz_999'])
+        self.assertEqual(code, 0)
+        self.assertIn("Found 0 skill(s)", out)
+        self.assertIn("No skills found matching filter", out)
+
+    # TC-CLI-SEARCH-05: Missing search term
+    def test_search_missing_term(self):
+        code, out, err = self.run_cli(['search'])
+        self.assertEqual(code, 1)
+        self.assertIn("Usage:", err)
+
+    # TC-CLI-INST-01: Valid skill installation
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_install_valid_skill(self, mock_catalog):
+        code, out, err = self.run_cli(['install', 'antigravity-skills-manager'])
+        self.assertEqual(code, 0)
+        self.assertIn("[OK] Successfully installed", out)
+        installed_file = os.path.join(self.temp_dir.name, 'antigravity-skills-manager', 'SKILL.md')
+        self.assertTrue(os.path.exists(installed_file))
+        with open(installed_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn("name: antigravity-skills-manager", content)
+
+    # TC-CLI-INST-02: Re-installation / Overwrite
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_install_overwrite(self, mock_catalog):
+        code1, out1, err1 = self.run_cli(['install', 'antigravity-skills-manager'])
+        self.assertEqual(code1, 0)
+        code2, out2, err2 = self.run_cli(['install', 'antigravity-skills-manager'])
+        self.assertEqual(code2, 0)
+        self.assertIn("[OK] Successfully installed", out2)
+
+    # TC-CLI-INST-03: Non-existent skill ID
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_install_nonexistent_skill(self, mock_catalog):
+        code, out, err = self.run_cli(['install', 'unknown-skill-999'])
+        self.assertEqual(code, 1)
+        self.assertIn("Skill 'unknown-skill-999' not found in catalog", err)
+
+    # TC-CLI-INST-04: Unmocked skill installation from disk catalog.json
+    def test_install_unmocked(self):
+        code, out, err = self.run_cli(['install', 'antigravity-skills-manager'])
+        self.assertEqual(code, 0, f"Unmocked install failed: {err}")
+        self.assertIn("[OK] Successfully installed", out)
+        installed_file = os.path.join(self.temp_dir.name, 'antigravity-skills-manager', 'SKILL.md')
+        self.assertTrue(os.path.exists(installed_file))
+
+    # TC-CLI-INSTD-01: Clean directory state
+    def test_installed_empty(self):
+        code, out, err = self.run_cli(['installed'])
+        self.assertEqual(code, 0)
+        self.assertIn("No skills currently installed", out)
+
+    # TC-CLI-INSTD-02: Multiple installed skills
+    @patch('skills_cli.load_catalog', return_value=MOCK_CATALOG)
+    def test_installed_multiple(self, mock_catalog):
+        self.run_cli(['install', 'antigravity-skills-manager'])
+        code, out, err = self.run_cli(['installed'])
+        self.assertEqual(code, 0)
+        self.assertIn("antigravity-skills-manager", out)
+        self.assertIn("[OK] SKILL.md", out)
+
+    # TC-CLI-INSTD-03: Non-skill folder ignore/flag
+    def test_installed_folder_without_skill_md(self):
+        fake_folder = os.path.join(self.temp_dir.name, 'dummy-folder')
+        os.makedirs(fake_folder, exist_ok=True)
+        code, out, err = self.run_cli(['installed'])
+        self.assertEqual(code, 0)
+        self.assertIn("dummy-folder", out)
+        self.assertIn("[X] No SKILL.md", out)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Integrates the `antigravity-skills-manager` skill, pure Python standard library CLI engine (`skills_cli.py`), root plugin manifest (`plugin.json`), catalog indexing (`catalog.json`), and full test suite (`tests/`).

## Features Included
- `skills/antigravity-skills-manager/SKILL.md`: AGY standard skill definition and documentation.
- `skills_cli.py`: Pure stdlib engine (`urllib.request`, `json`, `os`, `sys`) with zero external dependencies and `# ponytail:` comments supporting `list`, `search`, `install`, `installed` subcommands.
- `plugin.json`: Root manifest enabling direct `agy plugin install https://github.com/tonicofonico/antigravity-skills` installation.
- `catalog.json`: Indexed entry with total count updated to 307.
- Test suites: 17 Python unittests, 35 Node tests, zero catalog drift.

## Verification
- Passed 100% Python unittests, 100% Node tests, skill validation, zero catalog drift check, and unmocked CLI execution.
