### PR TITLE
Replace retired Claude model id in the two AI review skills

### DIFF
--- a/skills/code-review-ai-ai-review/SKILL.md
+++ b/skills/code-review-ai-ai-review/SKILL.md
@@ -388,7 +388,7 @@ Return JSON array:
 """
 
         response = self.anthropic_client.messages.create(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-sonnet-4-6",
             max_tokens=8000, temperature=0.2,
             messages=[{"role": "user", "content": prompt}]
         )

--- a/skills/performance-testing-review-ai-review/SKILL.md
+++ b/skills/performance-testing-review-ai-review/SKILL.md
@@ -388,7 +388,7 @@ Return JSON array:
 """
 
         response = self.anthropic_client.messages.create(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-sonnet-4-6",
             max_tokens=8000, temperature=0.2,
             messages=[{"role": "user", "content": prompt}]
         )


### PR DESCRIPTION
Two skills call the Anthropic API with `claude-3-5-sonnet-20241022`. That id reached its retirement date on 28 October 2025 and is listed on the [model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations). Anyone who copies the example as written gets a request the API will not serve.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `skills/code-review-ai-ai-review/SKILL.md` | 391 | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |
| `skills/performance-testing-review-ai-review/SKILL.md` | 391 | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |

Sonnet 4.6 is the closest current model to what the example was reaching for. The surrounding `max_tokens` and `temperature` values still work with it, so they are untouched.

Three other places mention Claude models and I left all of them alone.

`claude-3.7-sonnet` at line 99 of both files sits inside an invented `AIEngine(...)` router next to `"gpt-4o"`. It is illustrating routing logic rather than naming a real API id, so changing it would be editing your prose rather than fixing a call.

`agent-orchestration-multi-agent-optimize/SKILL.md` has `claude-4-sonnet` and `claude-4-haiku` in a per-token cost dictionary. Prices are your data. I am not going to guess at them.

`llm-application-dev-langchain-agent/SKILL.md` uses `claude-sonnet-4-5`, which the API still serves.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model IDs, so I am mentioning that up front rather than leaving you to wonder. I have not run these examples against the API to reproduce a failure, the claim rests on the published retirement date. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
